### PR TITLE
FIxed Library animation error

### DIFF
--- a/pages/7_Library.py
+++ b/pages/7_Library.py
@@ -14,7 +14,7 @@ from streamlit_lottie import st_lottie
 
 # Animation Section
 try:
-    with open('assets\Library.json', encoding='utf-8') as anim_source:
+    with open('assets/Library.json', encoding='utf-8') as anim_source:
         animation_data = json.load(anim_source)
         st_lottie(animation_data, height=200, key="About")
 except FileNotFoundError:


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1a0e324b-03e5-4a0c-9cde-11af62bd71a9)


. File Path Handling
The path "assets\Library.json" uses a backslash (\) which is platform-specific (Windows). Converted it to a more universal format